### PR TITLE
feat: add GetIt::findFactory method and Expose ServiceFactory,ServiceFactoryType

### DIFF
--- a/lib/get_it.dart
+++ b/lib/get_it.dart
@@ -10,6 +10,22 @@ import 'package:collection/collection.dart' show IterableExtension;
 
 part 'get_it_impl.dart';
 
+/// You will see a rather esoteric looking test `(const Object() is! T)` at several places
+/// /// it tests if [T] is a real type and not Object or dynamic
+
+/// For each registered factory/singleton a [_ServiceFactory<T>] is created
+/// it holds either the instance of a Singleton or/and the creation functions
+/// for creating an instance when [get] is called
+///
+/// There are three different types
+enum ServiceFactoryType {
+  alwaysNew,
+
+  /// factory which means on every call of [get] a new instance is created
+  constant, // normal singleton
+  lazy, // lazy
+}
+
 /// If your singleton that you register wants to use the manually signalling
 /// of its ready state, it can implement this interface class instead of using
 /// the [signalsReady] parameter of the registration functions
@@ -24,6 +40,7 @@ abstract class WillSignalReady {}
 /// This can be helpful to unsubscribe / resubscribe from Streams or Listenables
 abstract mixin class ShadowChangeHandlers {
   void onGetShadowed(Object shadowing);
+
   void onLeaveShadow(Object shadowing);
 }
 
@@ -113,6 +130,31 @@ class WaitingTimeOutException implements Exception {
     }
     return super.toString();
   }
+}
+
+abstract class ServiceFactory<T extends Object> {
+  ServiceFactoryType get factoryType;
+
+  /// In case of a named registration the instance name is here stored for easy access
+  String? get instanceName;
+
+  /// true if one of the async registration functions have been used
+  bool get isAsync;
+
+  /// If an existing Object gets registered or an async/lazy Singleton has finished
+  /// its creation, it is stored here
+  Object? get instance;
+
+  /// the type that was used when registering, used for runtime checks
+  Type get registrationType;
+
+  bool get isReady;
+
+  bool get isNamedRegistration => instanceName != null;
+
+  String get debugName => '$instanceName : $registrationType';
+
+  bool get canBeWaitedFor;
 }
 
 /// Very simple and easy to use service locator
@@ -366,6 +408,10 @@ abstract class GetIt {
     String? instanceName,
     DisposingFunc<T>? dispose,
   });
+
+  /// find the first factory that matches the type [T]/[instanceName] or the [instance]
+  ServiceFactory? findFirstFactory<T extends Object>(
+      {Object? instance, String? instanceName});
 
   /// Tests if an [instance] of an object or aType [T] or a name [instanceName]
   /// is registered inside GetIt

--- a/lib/get_it_impl.dart
+++ b/lib/get_it_impl.dart
@@ -26,25 +26,12 @@ void _debugOutput(Object message) {
   }
 }
 
-/// You will see a rather esoteric looking test `(const Object() is! T)` at several places
-/// /// it tests if [T] is a real type and not Object or dynamic
-
-/// For each registered factory/singleton a [_ServiceFactory<T>] is created
-/// it holds either the instance of a Singleton or/and the creation functions
-/// for creating an instance when [get] is called
-///
-/// There are three different types
-enum _ServiceFactoryType {
-  alwaysNew,
-
-  /// factory which means on every call of [get] a new instance is created
-  constant, // normal singleton
-  lazy, // lazy
-}
+typedef _ServiceFactoryType = ServiceFactoryType;
 
 /// If I use `Singleton` without specifier in the comments I mean normal and lazy
 
-class _ServiceFactory<T extends Object, P1, P2> {
+class _ServiceFactory<T extends Object, P1, P2> extends ServiceFactory<T> {
+  @override
   final _ServiceFactoryType factoryType;
 
   final _GetItImplementation _getItInstance;
@@ -65,16 +52,20 @@ class _ServiceFactory<T extends Object, P1, P2> {
   final DisposingFunc<T>? disposeFunction;
 
   /// In case of a named registration the instance name is here stored for easy access
+  @override
   final String? instanceName;
 
   /// true if one of the async registration functions have been used
+  @override
   final bool isAsync;
 
   /// If an existing Object gets registered or an async/lazy Singleton has finished
   /// its creation, it is stored here
+  @override
   Object? instance;
 
   /// the type that was used when registering, used for runtime checks
+  @override
   late final Type registrationType;
 
   /// to enable Singletons to signal that they are ready (their initialization is finished)
@@ -87,12 +78,16 @@ class _ServiceFactory<T extends Object, P1, P2> {
   /// they are stored here
   final List<Type> objectsWaiting = [];
 
+  @override
   bool get isReady => _readyCompleter.isCompleted;
 
+  @override
   bool get isNamedRegistration => instanceName != null;
 
+  @override
   String get debugName => '$instanceName : $registrationType';
 
+  @override
   bool get canBeWaitedFor =>
       shouldSignalReady || pendingResult != null || isAsync;
 
@@ -1230,19 +1225,25 @@ class _GetItImplementation implements GetIt {
     }
   }
 
+  @override
+  ServiceFactory? findFirstFactory<T extends Object>(
+      {Object? instance, String? instanceName}) {
+    if (instance != null) {
+      return _findFirstFactoryByInstanceOrNull(instance);
+    } else {
+      return _findFirstFactoryByNameAndTypeOrNull<T>(instanceName);
+    }
+  }
+
   /// Tests if an [instance] of an object or aType [T] or a name [instanceName]
   /// is registered inside GetIt
   @override
   bool isRegistered<T extends Object>({
     Object? instance,
     String? instanceName,
-  }) {
-    if (instance != null) {
-      return _findFirstFactoryByInstanceOrNull(instance) != null;
-    } else {
-      return _findFirstFactoryByNameAndTypeOrNull<T>(instanceName) != null;
-    }
-  }
+  }) =>
+      findFirstFactory<T>(instance: instance, instanceName: instanceName) !=
+      null;
 
   /// Unregister an instance of an object or a factory/singleton by Type [T] or by name [instanceName]
   /// if you need to dispose any resources you can do it using [disposingFunction] function


### PR DESCRIPTION
This change allows developers to programmatically query the state of a service's underlying ServiceFactory within the container. This is achieved by making the ServiceFactory class and ServiceFactoryType enum public, and by adding a new findFactory method. This enables the creation of more powerful and dynamic tools and frameworks on top of the GetIt platform.

Motivation for Framework and Tool Developers
When building a framework or developer tool on top of GetIt, it's often necessary to understand how a service was registered, not just that it exists. This new API provides that capability, which is valuable for:

Lifecycle-aware Logic: A framework can now verify that a service intended for caching is correctly registered as a singleton and provide warnings to the user if it's misconfigured.

Dependency Analysis Tools: A developer tool could scan the container, visualize the dependency graph, and label each node with its registration type (singleton, lazySingleton, factory), providing a clear architectural overview.

Automatic Validation: A testing framework could automatically assert that services with a specific annotation are registered with an expected lifecycle, reducing boilerplate and enforcing conventions.

Key Changes
Exposed ServiceFactory and ServiceFactoryType:

The ServiceFactory abstract class and the ServiceFactoryType enum are now public APIs, allowing them to be used in external code.

New GetIt.findFactory Method:

A new method, ServiceFactory? findFactory<T extends Object>({String? instanceName}), has been added to the GetIt interface.

It returns the ServiceFactory instance for a given type, allowing access to its .type property and other potential factory state